### PR TITLE
Handle blur event to track password validation

### DIFF
--- a/Client/src/app/documents/components/CreateLink.tsx
+++ b/Client/src/app/documents/components/CreateLink.tsx
@@ -53,7 +53,7 @@ export default function CreateLink({ onClose, open, documentId }: CreateLinkProp
 		requiredUserDetailsOption: 1,
 	};
 
-	const { values, setValues, validateAll, getError } = useValidatedFormData<LinkFormValues>({
+	const { values, setValues, validateAll, getError, handleBlur } = useValidatedFormData<LinkFormValues>({
 		initialValues: initialFormValues,
 		validationRules
 	});
@@ -144,6 +144,7 @@ export default function CreateLink({ onClose, open, documentId }: CreateLinkProp
 	const { loading, handleSubmit, error, toast } = useFormSubmission({
 		onSubmit: async () => {
 			const hasError = validateAll();
+
 			if (hasError) {
 				throw new Error('Please correct any errors before generating a link.');
 			}
@@ -232,6 +233,7 @@ export default function CreateLink({ onClose, open, documentId }: CreateLinkProp
 							<SharingOptionsAccordion
 								getError={getError}
 								formValues={values}
+								handleBlur={handleBlur}
 								handleInputChange={handleInputChange}
 								isPasswordVisible={isPasswordVisible}
 								setIsPasswordVisible={setIsPasswordVisible}

--- a/Client/src/app/documents/components/SharingOptionsAccordion.tsx
+++ b/Client/src/app/documents/components/SharingOptionsAccordion.tsx
@@ -16,6 +16,7 @@ interface SharingOptionsAccordionProps {
 	expirationType: string;
 	getError: (fieldName: keyof LinkFormValues) => string;
 	handleExpirationChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+	handleBlur: (event: React.FocusEvent<HTMLInputElement>) => void;
 }
 
 const SharingOptionsAccordion = ({
@@ -25,6 +26,7 @@ const SharingOptionsAccordion = ({
 	isPasswordVisible,
 	setIsPasswordVisible,
 	expirationType,
+	handleBlur,
 	handleExpirationChange,
 }: SharingOptionsAccordionProps) => {
 	return (
@@ -77,7 +79,6 @@ const SharingOptionsAccordion = ({
 				mb={4}
 				ml={13}>
 				<FormInput
-
 					id='password'
 					minWidth={420}
 					value={formValues.password}
@@ -94,6 +95,7 @@ const SharingOptionsAccordion = ({
 					type={isPasswordVisible ? 'text' : 'password'}
 					disabled={!formValues.requirePassword}
 					errorMessage={getError('password')}
+					onBlur={handleBlur}
 				/>
 				<IconButton
 					size='large'


### PR DESCRIPTION
- Shows validation when the focus is out.
- Creates an error if validation fails stopping to send the api request.