### PR TITLE
Avoid API call for each document while rendering documents table

### DIFF
--- a/Client/src/app/documents/components/DocumentsTableRow.tsx
+++ b/Client/src/app/documents/components/DocumentsTableRow.tsx
@@ -132,14 +132,16 @@ const DocumentsTableRow = ({ document, onDelete }: Props) => {
 						height={20}
 					/>
 				</IconButton>
-				<ActionMenu
-					open={open}
-					anchorEl={anchorEl}
-					onDelete={onDelete}
-					documentId={document.document_id}
-					onClose={handleMenuClose}
-					onAnalytics={routetoDocument}
-				/>
+				{open && (
+					<ActionMenu
+						open={open}
+						anchorEl={anchorEl}
+						onDelete={onDelete}
+						documentId={document.document_id}
+						onClose={handleMenuClose}
+						onAnalytics={routetoDocument}
+					/>
+				)}
 			</TableCell>
 		</TableRow>
 	);


### PR DESCRIPTION
Use boolean `open` to call ActionMenu. 
 
 Though by default `ActionMenu` doesnt get renderred in UI, but the component is getting called. doing `API` request to individual document by `id`

![409813050-0348dae3-38f6-4d5e-af15-1457eba123c5](https://github.com/user-attachments/assets/50294270-af53-45dc-8139-9650b001128b)

 Using the flag will fix this unwanted API call. And only the document by `id` api call will happen when a user clicks on the Action button (DEFAULT BEHAVIOUR)