### PR TITLE
hotfix - refactor/document-access

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -9,17 +9,18 @@ datasource db {
   directUrl = env("DIRECT_URL")
 }
 
-model ArchivedUser {
-  id         Int      @id @default(autoincrement())
-  user_id    String   @unique @default(cuid())
-  first_name String   @default("")
-  last_name  String   @default("")
-  email      String   @unique @default("")
-  password   String
-  created_at DateTime @default(now()) @db.Timestamptz(6)
-  role       UserRole @default(USER)
-  address    String?  @default("")
-}
+// Temporary disabled ArchivedUser model - Can re-enable later when we have Delete User functionality
+// model ArchivedUser {
+//   id         Int      @id @default(autoincrement())
+//   user_id    String   @unique @default(uuid())
+//   first_name String   @default("")
+//   last_name  String   @default("")
+//   email      String   @unique @default("")
+//   password   String
+//   created_at DateTime @default(now()) @db.Timestamptz(6)
+//   role       UserRole @default(USER)
+//   address    String?  @default("")
+// }
 
 model PasswordResetToken {
   id         Int       @id @default(autoincrement())
@@ -31,35 +32,49 @@ model PasswordResetToken {
 }
 
 model User {
-  id                 Int                  @id @default(autoincrement())
-  user_id            String               @unique
-  first_name         String               @default("")
-  last_name          String               @default("")
-  email              String               @unique @default("")
-  password           String
-  created_at         DateTime             @default(now()) @db.Timestamptz(6)
-  role               UserRole             @default(ADMIN)
-  status             Status
-  verification_token String
-  token_expires_at   DateTime             @db.Timestamptz(6)
-  updated_at         DateTime             @updatedAt @db.Timestamptz(6)
+  id                 Int          @id @default(autoincrement())
+  user_id            String       @unique
+  auth_provider      AuthProvider @default(CREDENTIALS)
+  auth0_sub          String?      @unique
+  first_name         String       @default("")
+  last_name          String       @default("")
+  email              String       @unique @default("") @db.Text
+  password           String?
+  avatar_url         String?
+  created_at         DateTime     @default(now()) @db.Timestamptz(6)
+  role               UserRole     @default(USER)
+  status             Status       @default(UNVERIFIED)
+  verification_token String?
+  token_expires_at   DateTime?
+  updated_at         DateTime     @updatedAt @db.Timestamptz(6)
+
   PasswordResetToken PasswordResetToken[]
   Document           Document[]
   documentLink       DocumentLink[]
 }
 
+enum AuthProvider {
+  CREDENTIALS
+  AUTH0
+  GOOGLE // future expansion
+}
+
 model Document {
-  id           Int            @id @default(autoincrement())
-  document_id  String         @unique @default(cuid())
-  user_id      String
-  fileName     String
-  filePath     String
-  fileType     String
-  size         Int
-  createdAt    DateTime       @default(now()) @db.Timestamptz(6)
-  updatedAt    DateTime       @updatedAt @db.Timestamptz(6)
-  User         User           @relation(fields: [user_id], references: [user_id], onDelete: Cascade)
+  id          Int      @id @default(autoincrement())
+  document_id String   @unique @default(uuid())
+  user_id     String
+  fileName    String
+  filePath    String   @db.Text
+  fileType    String
+  size        Int
+  createdAt   DateTime @default(now()) @db.Timestamptz(6)
+  updatedAt   DateTime @updatedAt @db.Timestamptz(6)
+  User        User     @relation(fields: [user_id], references: [user_id], onDelete: Cascade)
+
   documentLink DocumentLink[]
+
+  //Helpful indexes for look-ups
+  @@index([user_id])
 }
 
 enum Status {
@@ -70,6 +85,7 @@ enum Status {
 
 enum UserRole {
   ADMIN
+  MEMBER
   USER
 }
 
@@ -92,6 +108,12 @@ model DocumentLink {
   User     User     @relation(fields: [createdByUserId], references: [user_id], onDelete: Cascade)
 
   documentLinkVisitors DocumentLinkVisitor[]
+
+  // Composite uniqueness: alias must be unique only within its document
+  @@unique([documentId, alias], name: "document_alias_unique")
+  // Helpful indexes for look-ups
+  @@index([documentId])
+  @@index([createdByUserId])
 }
 
 model DocumentLinkVisitor {
@@ -99,11 +121,14 @@ model DocumentLinkVisitor {
   documentLinkId  String
   firstName       String   @default("")
   lastName        String   @default("")
-  email           String   @default("")
+  email           String   @default("") @db.Text
   visitorMetaData Json? // Any additional user details will be here.
   visitedAt       DateTime @default(now()) @db.Timestamptz(6)
   updatedAt       DateTime @updatedAt @db.Timestamptz(6)
 
   // Relations
   documentLink DocumentLink @relation(fields: [documentLinkId], references: [documentLinkId], onDelete: Cascade)
+
+  // Helpful indexes for look-ups
+  @@index([documentLinkId, visitedAt])
 }

--- a/src/app/documents/components/CreateLink.tsx
+++ b/src/app/documents/components/CreateLink.tsx
@@ -236,7 +236,7 @@ export default function CreateLink({ open, documentId, onClose }: CreateLinkProp
 
 			const payload = buildRequestPayload();
 
-			// Needs to be fixed due Tanstack Query and useFormSubmission conflict - Loading states, Error handling, etc. don't work as expected
+			/** Needs to be fixed due Tanstack Query and useFormSubmission conflict - Loading states, Error handling, etc. don't work as expected*/
 
 			// createLink(
 			// 	{ documentId, payload },
@@ -269,6 +269,10 @@ export default function CreateLink({ open, documentId, onClose }: CreateLinkProp
 			// 	},
 			// );
 
+			/**
+			 * TODO: This is a temporary solution to handle the loading state and error handling.
+			 * Working on a better solution to handle the loading state and error handling.
+			 */
 			const { link } = await createLink({ documentId, payload });
 			onClose('submitted', link.linkUrl);
 

--- a/src/app/documents/components/SharingOptionsAccordion.tsx
+++ b/src/app/documents/components/SharingOptionsAccordion.tsx
@@ -70,22 +70,26 @@ export default function SharingOptionsAccordion(props: SharingOptionsAccordionPr
 							return (
 								<Box
 									display='flex'
-									gap={5}>
-									{sortedSelected.map((value) => (
-										<Chip
-											key={value}
-											label={value}
-											size='small'
-										/>
-									))}
+									gap={2}>
+									{sortedSelected.map((key) => {
+										const field = visitorFieldsConfig.find((f) => f.key === key);
+										return (
+											<Chip
+												key={key}
+												label={field?.label || key}
+												sx={{ px: '0.8rem' }}
+												size='small'
+											/>
+										);
+									})}
 								</Box>
 							);
 						}}>
-						{visitorFieldsConfig.map(({ key, label }) => (
+						{visitorFieldsConfig.map((visitorField) => (
 							<MenuItem
-								key={key}
-								value={key}>
-								{label}
+								key={visitorField.key}
+								value={visitorField.key}>
+								{visitorField.label}
 							</MenuItem>
 						))}
 					</Select>

--- a/src/hooks/documentAccess/useVisitorSubmission.ts
+++ b/src/hooks/documentAccess/useVisitorSubmission.ts
@@ -8,13 +8,18 @@ const submitVisitorDetails = async ({ linkId, payload }: { linkId: string; paylo
 };
 
 const useVisitorSubmission = () => {
-	return useMutation({
-		mutationFn: async (variables: { linkId: string; payload: any }) =>
-			submitVisitorDetails(variables),
+	const mutation = useMutation({
+		mutationFn: submitVisitorDetails,
 		onError: (error) => {
-			console.error('Error adding document: ', error);
+			console.error('Error submitting visitor details: ', error);
 		},
 	});
+
+	return {
+		mutateAsync: mutation.mutateAsync,
+		isPending: mutation.isPending,
+		error: mutation.error,
+	};
 };
 
 export default useVisitorSubmission;

--- a/src/hooks/documents/useCreateLink.ts
+++ b/src/hooks/documents/useCreateLink.ts
@@ -16,6 +16,7 @@ export default function useCreateLink() {
 	const queryClient = useQueryClient();
 
 	const mutation = useMutation({
+		// Returns a promise that resolves to the response data, thus fixing the useFormSubmission issue
 		mutationFn: async ({
 			documentId,
 			payload,

--- a/src/hooks/documents/useCreateLink.ts
+++ b/src/hooks/documents/useCreateLink.ts
@@ -13,23 +13,24 @@ interface DocumentLinkResponse {
 }
 
 export default function useCreateLink() {
-	const createLink = async ({
-		documentId,
-		payload,
-	}: CreateLinkParams): Promise<DocumentLinkResponse> => {
-		const response = await axios.post(`/api/documents/${documentId}/links`, payload);
-		return response.data;
-	};
-
 	const queryClient = useQueryClient();
 
-	return useMutation({
-		mutationFn: createLink,
+	const mutation = useMutation({
+		mutationFn: async ({
+			documentId,
+			payload,
+		}: CreateLinkParams): Promise<DocumentLinkResponse> => {
+			const response = await axios.post(`/api/documents/${documentId}/links`, payload);
+			return response.data;
+		},
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: ['links'] });
 		},
-		onError: (error) => {
-			console.error('Error creating link: ', error);
-		},
 	});
+
+	return {
+		mutateAsync: mutation.mutateAsync,
+		isPending: mutation.isPending,
+		error: mutation.error,
+	};
 }

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -4,7 +4,7 @@ export { default as useFetchDocuments } from './documents/useFetchDocuments';
 export { default as useUploadDocument } from './documents/useUploadDocument';
 export { default as useDeleteDocument } from './documents/useDeleteDocument';
 
-export { default as useCreateLink } from './documentLinks/useCreateLink';
+export { default as useCreateLink } from './documents/useCreateLink';
 
 export { default as useDocumentAnalytics } from './useDocumentAnalytics';
 export { default as useDocumentData } from './useDocumentData';

--- a/src/hooks/useValidatedFormData.ts
+++ b/src/hooks/useValidatedFormData.ts
@@ -86,6 +86,9 @@ export function useValidatedFormData<T extends object>({
 	 * Returns true if there's ANY failing rule in the entire form.
 	 */
 	const validateAll = (): boolean => {
+		setTouched((prev) => Object.fromEntries(Object.keys(prev).map((k) => [k, true])) as any);
+		setShowAllErrors(true);
+
 		let hasError = false;
 		for (const key in validationRules) {
 			const errorMsg = getError(key as keyof T);

--- a/src/shared/utils/stringUtils.ts
+++ b/src/shared/utils/stringUtils.ts
@@ -67,7 +67,7 @@ export const convertTransparencyToHex = (transparency: number): string => {
  * @param config An array of config objects with a `key` property used to define the desired order.
  * @returns A new array of field keys sorted according to the config array.
  */
-export function sortFields(fields: string[], config: { key: string }[]): string[] {
+export function sortFields(fields: string[], config: { key: string; label: string }[]): string[] {
 	return [...fields].sort(
 		(fieldA, fieldB) =>
 			config.findIndex((item) => item.key === fieldA) -

--- a/src/theme/globalTheme.ts
+++ b/src/theme/globalTheme.ts
@@ -567,8 +567,11 @@ const globalTheme = createTheme({
 					backgroundColor: 'inherit',
 					color: text.secondary,
 					minWidth: 100,
-					'&:hover, &.Mui-selected, &.Mui-selected:hover, &.Mui-selected.Mui-focusVisible': {
+					'&:hover': {
 						backgroundColor: hover.tertiary,
+					},
+					'&.Mui-selected:hover': {
+						backgroundColor: `${hover.primary} !important`,
 					},
 					'@media (min-width:600px)': {
 						fontSize: '0.7rem',


### PR DESCRIPTION
### ✅ Changes Made

- Added a Prisma constraint to ensure each `alias` is unique **per `documentId`**, using `@@unique([documentId, alias])`.
- In `SharingOptionsAccordion`, updated `Select` to store values by `key` and display user-friendly `label` values (e.g., "Name" instead of "name").
- Refactored `useCreateLink` to return `{ mutateAsync, isPending, error }` for cleaner integration in components.
- Refactored `CreateLink.useFormSubmission` to properly handle mutation state and fix loading state & error handling.
- Fixed a bug in `VisitorInfoModal` reported in  **`Error.pdf` Bug #*2***, where untouched required fields were not validated on first submit.
  - Added validation to block submission until all required fields are filled.
  - Integrated loading state to disable the Confirm button during submission.

---

### 📝 Notes

- The validation in `VisitorInfoModal` is a temporary fix. A full refactor using `Zod` is planned.
- Alias uniqueness is now scoped per document rather than globally.
