### PR TITLE
Enhance visitor tracking and contact storage logic

### DIFF
--- a/src/app/api/_services/linkService.ts
+++ b/src/app/api/_services/linkService.ts
@@ -138,6 +138,23 @@ export class LinkService {
 	}
 
 	/**
+	 * Retrieves all visitors who accessed a specific link under this document.
+	 */
+	static async getDocumentLinkVisitors(userId: string, documentId: string, linkId: string) {
+		// Ensure the link belongs to the specified document and user (i.e., verify ownership)
+		const link = await prisma.documentLink.findFirst({
+			where: { documentLinkId: linkId, Document: { document_id: documentId, user_id: userId } },
+		});
+		if (!link) return null; // link not found or no access
+
+		// Query link visitors
+		return prisma.documentLinkVisitor.findMany({
+			where: { documentLinkId: linkId },
+			orderBy: { visitedAt: 'desc' },
+		});
+	}
+
+	/**
 	 * Generates a signed file URL for the Document associated with this link,
 	 * checking if the link is expired. Throws if link invalid/expired.
 	 */

--- a/src/app/api/contacts/route.ts
+++ b/src/app/api/contacts/route.ts
@@ -35,6 +35,7 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
 					where: {
 						email: visitor.email,
 						documentLinkId: { in: linkIds },
+						OR: [{ firstName: { not: '' } }, { lastName: { not: '' } }],
 					},
 					orderBy: { updatedAt: 'desc' },
 					include: {
@@ -46,15 +47,10 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
 					return null;
 				}
 
-				const firstName = lastVisit.firstName?.trim() || null;
-				const lastName = lastVisit.lastName?.trim() || null;
-				const fullName =
-					firstName || lastName ? `${firstName || ''} ${lastName || ''}`.trim() : null;
-
 				return {
 					id: lastVisit.id,
-					name: fullName,
-					email: visitor.email || null,
+					name: `${lastVisit.firstName.trim()} ${lastVisit.lastName.trim()}`,
+					email: visitor.email,
 					lastViewedLink: lastVisit.documentLink?.alias || lastVisit.documentLink?.linkUrl || null,
 					lastActivity: lastVisit.updatedAt || null,
 					totalVisits: visitor._count.email || 0,
@@ -62,7 +58,7 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
 			}),
 		);
 
-		const contacts = visitorDetails.filter(Boolean);
+		const contacts = visitorDetails.filter((visitor) => visitor && visitor.email && visitor.name);
 
 		return NextResponse.json({ data: contacts }, { status: 200 });
 	} catch (error) {

--- a/src/app/api/documents/[documentId]/links/[linkId]/log/route.ts
+++ b/src/app/api/documents/[documentId]/links/[linkId]/log/route.ts
@@ -1,0 +1,45 @@
+import { authService, createErrorResponse, LinkService } from '@/app/api/_services';
+import { NextRequest, NextResponse } from 'next/server';
+
+/**
+ * GET /api/documents/[documentId]/links/[linkId]/log
+ * Lists visitors for a specific link within a document.
+ */
+export async function GET(
+	req: NextRequest,
+	props: { params: Promise<{ documentId: string; linkId: string }> },
+) {
+	try {
+		const userId = await authService.authenticate();
+
+		const { documentId, linkId } = await props.params;
+		const linkVisitors = await LinkService.getDocumentLinkVisitors(userId, documentId, linkId);
+
+		if (linkVisitors === null) {
+			return NextResponse.json({ error: 'Link not found or access denied.' }, { status: 404 });
+		}
+
+		if (linkVisitors.length === 0) {
+			return NextResponse.json({ data: [] }, { status: 200 });
+		}
+
+		const visitors = linkVisitors?.map((visitor) => {
+			const firstName = visitor.firstName?.trim() || null;
+			const lastName = visitor.lastName?.trim() || null;
+			const fullName = firstName || lastName ? `${firstName || ''} ${lastName || ''}`.trim() : null;
+
+			return {
+				id: visitor.id,
+				linkId: visitor.documentLinkId,
+				name: fullName,
+				email: visitor.email || null,
+				visitedAt: visitor.visitedAt,
+				visitorMetaData: visitor.visitorMetaData,
+			};
+		});
+
+		return NextResponse.json({ data: visitors }, { status: 200 });
+	} catch (error) {
+		return createErrorResponse('Server error while fetching visitors.', 500, error);
+	}
+}

--- a/src/app/api/public_links/[linkId]/access/route.ts
+++ b/src/app/api/public_links/[linkId]/access/route.ts
@@ -28,7 +28,9 @@ export async function POST(req: NextRequest, props: { params: Promise<{ linkId: 
 		}
 
 		// 4) Log visitor.
-		await LinkService.logVisitor(linkId, firstName, lastName, email);
+		if (!link.isPublic) {
+			await LinkService.logVisitor(linkId, firstName, lastName, email);
+		}
 
 		// 5) Get a signed URL for the doc
 		try {

--- a/src/app/documents/[documentId]/components/InfoTable.tsx
+++ b/src/app/documents/[documentId]/components/InfoTable.tsx
@@ -16,7 +16,7 @@ import {
 
 import InfoTableHeader from './InfoTableHeader';
 import InfoTableRow from './InfoTableRow';
-import { Paginator } from '@/components';
+import { EmptyState, Paginator } from '@/components';
 
 import { Contact, LinkDetail } from '@/shared/models';
 import { useDocumentData, useSort } from '@/hooks';
@@ -91,7 +91,7 @@ export default function InfoTable({ variant, documentId }: InfoTableProps) {
 						{isLinkTableEmpty && (
 							<TableRow>
 								<TableCell
-									colSpan={4}
+									colSpan={5}
 									sx={{ textAlign: 'center', py: { sm: '0.5rem', md: '0.7rem', lg: '0.9rem' } }}>
 									<Button
 										variant='contained'
@@ -108,7 +108,7 @@ export default function InfoTable({ variant, documentId }: InfoTableProps) {
 								<TableCell
 									colSpan={5}
 									sx={{ textAlign: 'center', py: { sm: '0.5rem', md: '0.7rem', lg: '0.9rem' } }}>
-									<Typography>No visitor data found.</Typography>
+									<EmptyState message='No visitor data found.' />
 								</TableCell>
 							</TableRow>
 						)}

--- a/src/app/documents/[documentId]/components/InfoTableHeader.tsx
+++ b/src/app/documents/[documentId]/components/InfoTableHeader.tsx
@@ -30,7 +30,7 @@ export default function InfoTableHeader({
 	if (variant === 'linkTable') {
 		return (
 			<TableRow>
-				<TableCell sx={{ width: '45%', pl: 20 }}>LINK</TableCell>
+				<TableCell sx={{ width: '45%', pl: '2.5rem' }}>LINK</TableCell>
 				<TableCell sx={{ width: '20%', textAlign: 'center' }}>
 					<TableSortLabel
 						active={orderBy === 'lastActivity'}
@@ -41,8 +41,9 @@ export default function InfoTableHeader({
 						LAST VIEWED
 					</TableSortLabel>
 				</TableCell>
-				<TableCell sx={{ width: '25%', textAlign: 'center' }}>VIEWS</TableCell>
+				<TableCell sx={{ width: '10%', textAlign: 'center' }}>VIEWS</TableCell>
 				<TableCell sx={{ width: '10%', textAlign: 'center' }}>ACTION</TableCell>
+				<TableCell sx={{ width: '15%', textAlign: 'center' }}></TableCell>
 			</TableRow>
 		);
 	}
@@ -50,7 +51,7 @@ export default function InfoTableHeader({
 	// visitorTable
 	return (
 		<TableRow>
-			<TableCell sx={{ width: '30%', pl: 20 }}>VISITOR</TableCell>
+			<TableCell sx={{ width: '30%', pl: '2.5rem' }}>VISITOR</TableCell>
 			<TableCell sx={{ width: '25%', textAlign: 'center' }}>
 				<TableSortLabel
 					active={orderBy === 'lastActivity'}

--- a/src/app/documents/[documentId]/components/InfoTableRow.tsx
+++ b/src/app/documents/[documentId]/components/InfoTableRow.tsx
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { useState } from 'react';
 
-import { Box, IconButton, TableCell, TableRow, Tooltip, Typography } from '@mui/material';
+import { Box, IconButton, Button, TableCell, TableRow, Tooltip, Typography } from '@mui/material';
 
 import { CheckIcon, CopyIcon, TrashIcon } from '@/icons';
 
@@ -11,12 +11,15 @@ import { useModal, useToast } from '@/hooks';
 import { Contact, LinkDetail } from '@/shared/models';
 import { formatDateTime } from '@/shared/utils';
 
+import LinkVisitorModal from './LinkVisitorModal';
+
 interface InfoTableRowProps {
 	variant?: 'linkTable' | 'visitorTable';
 	documentDetail: LinkDetail | Contact;
 }
 
 export default function InfoTableRow({ documentDetail, variant }: InfoTableRowProps) {
+	const [linkVisitorOpen, setLinkVisitorOpen] = useState(false);
 	const [isLinkCopied, setIsLinkCopied] = useState(false);
 	const { showToast } = useToast();
 	const deleteModal = useModal();
@@ -27,10 +30,18 @@ export default function InfoTableRow({ documentDetail, variant }: InfoTableRowPr
 	const isVisitorDetail = (d: LinkDetail | Contact): d is Contact =>
 		(d as Contact).name !== undefined;
 
+	const handleOpenLinkVisitorModal = () => {
+		setLinkVisitorOpen(true);
+	};
+
+	const handleCloseLinkVisitorModal = () => {
+		setLinkVisitorOpen(false);
+	};
+
 	const handleDeleteLink = async () => {
 		try {
 			const link = documentDetail as LinkDetail;
-			await axios.delete(`/api/documents/${link.document_id}/links/${link.documentLinkId}`);
+			await axios.delete(`/api/documents/${link.documentId}/links/${link.linkId}`);
 
 			showToast({ message: 'Link deleted!', variant: 'success' });
 			deleteModal.closeModal();
@@ -55,7 +66,7 @@ export default function InfoTableRow({ documentDetail, variant }: InfoTableRowPr
 			<>
 				<TableRow hover>
 					<TableCell
-						sx={{ width: '45%', pl: 20, py: { sm: '0.7rem', md: '0.92rem', lg: '1.18rem' } }}>
+						sx={{ width: '45%', pl: '2.5rem', py: { sm: '0.7rem', md: '0.92rem', lg: '1.18rem' } }}>
 						<Box
 							display='flex'
 							alignItems='center'
@@ -86,19 +97,40 @@ export default function InfoTableRow({ documentDetail, variant }: InfoTableRowPr
 					<TableCell sx={{ width: '20%', textAlign: 'center' }}>
 						{formatDateTime(documentDetail.lastActivity)}
 					</TableCell>
-					<TableCell sx={{ width: '25%', textAlign: 'center' }}>
+					<TableCell sx={{ width: '10%', textAlign: 'center' }}>
 						{documentDetail.linkViews}
 					</TableCell>
 					<TableCell sx={{ width: '10%', textAlign: 'center' }}>
 						<IconButton onClick={deleteModal.openModal}>
 							<Box
 								component={TrashIcon}
-								width={{ sm: '1rem', md: '1.1rem', lg: '1.18rem' }}
+								width={{ sm: '1rem', md: '1.04rem', lg: '1.08rem' }}
 								height='auto'
 							/>
 						</IconButton>
 					</TableCell>
+					<TableCell sx={{ width: '15%', textAlign: 'center' }}>
+						<Tooltip
+							title='View visitors'
+							placement='bottom'>
+							<Button
+								variant='outlined'
+								size='small'
+								onClick={handleOpenLinkVisitorModal}>
+								View Log
+							</Button>
+						</Tooltip>
+					</TableCell>
 				</TableRow>
+
+				{/* Link Visitor Modal */}
+				<LinkVisitorModal
+					open={linkVisitorOpen}
+					documentId={documentDetail.documentId}
+					linkId={documentDetail.linkId}
+					linkAlias={documentDetail.alias || documentDetail.createdLink}
+					onClose={handleCloseLinkVisitorModal}
+				/>
 
 				{/* Confirm Delete Modal */}
 				<ModalWrapper
@@ -118,10 +150,12 @@ export default function InfoTableRow({ documentDetail, variant }: InfoTableRowPr
 	if (variant === 'visitorTable' && isVisitorDetail(documentDetail)) {
 		return (
 			<TableRow hover>
-				<TableCell sx={{ width: '30%', pl: 20 }}>
-					{documentDetail.name}
+				<TableCell sx={{ width: '30%', pl: '2.5rem' }}>
+					{documentDetail.name ? documentDetail.name : 'N/A'}
 					<br />
-					<Typography variant='caption'>{documentDetail.email}</Typography>
+					<Typography variant='caption'>
+						{documentDetail.email ? documentDetail.email : 'N/A'}
+					</Typography>
 				</TableCell>
 				<TableCell sx={{ width: '25%', textAlign: 'center' }}>
 					{formatDateTime(documentDetail.lastActivity)}

--- a/src/app/documents/[documentId]/components/LinkVisitorModal.tsx
+++ b/src/app/documents/[documentId]/components/LinkVisitorModal.tsx
@@ -1,0 +1,117 @@
+import { EmptyState } from '@/components';
+import { useFetchLinkVisitors } from '@/hooks';
+import { formatDateTime } from '@/shared/utils';
+
+import {
+	Box,
+	CircularProgress,
+	Dialog,
+	DialogContent,
+	DialogTitle,
+	Paper,
+	Table,
+	TableBody,
+	TableCell,
+	TableContainer,
+	TableHead,
+	TableRow,
+} from '@mui/material';
+
+interface LinkVisitorModalProps {
+	open: boolean;
+	documentId: string;
+	linkId: string;
+	linkAlias: string;
+	onClose: () => void;
+}
+
+export default function LinkVisitorModal({
+	open,
+	documentId,
+	linkId,
+	linkAlias,
+	onClose,
+}: LinkVisitorModalProps) {
+	const { data, isLoading } = useFetchLinkVisitors(documentId, linkId, open);
+
+	return (
+		<Dialog
+			open={open}
+			onClose={onClose}
+			fullWidth
+			maxWidth='md'>
+			<DialogTitle
+				variant='h2'
+				bgcolor='background.primary'
+				color='text.tertiary'>
+				Visitor Log - {linkAlias}
+			</DialogTitle>
+			<DialogContent>
+				<TableContainer
+					component={Paper}
+					sx={{ maxHeight: 500, mt: 11 }}>
+					<Table
+						aria-label='Info table'
+						stickyHeader>
+						<TableHead>
+							<TableRow>
+								<TableCell sx={{ width: '27%', pl: '2.5rem' }}>NAME</TableCell>
+								<TableCell sx={{ width: '33%', pl: '1.25rem' }}>EMAIL</TableCell>
+								<TableCell sx={{ width: '23%', textAlign: 'center' }}>VISITED AT</TableCell>
+								<TableCell sx={{ width: '17%', textAlign: 'center' }}>METADATA</TableCell>
+							</TableRow>
+						</TableHead>
+						<TableBody>
+							{isLoading && (
+								<TableRow>
+									<TableCell
+										colSpan={4}
+										sx={{ width: '100%' }}>
+										<Box
+											display='flex'
+											justifyContent='center'
+											mt={4}>
+											<CircularProgress />
+										</Box>
+									</TableCell>
+								</TableRow>
+							)}
+
+							{data?.length === 0 ? (
+								<TableRow>
+									<TableCell
+										colSpan={4}
+										sx={{ width: '100%' }}>
+										<EmptyState message='No visitors have accessed this link yet.' />
+									</TableCell>
+								</TableRow>
+							) : (
+								data?.map((visitor) => (
+									<TableRow key={visitor.id}>
+										<TableCell
+											sx={{
+												width: '27%',
+												pl: '2.5rem',
+												py: { sm: '0.98rem', md: '1.1rem', lg: '1.3rem' },
+											}}>
+											{visitor.name ? visitor.name : 'N/A'}
+										</TableCell>
+										<TableCell sx={{ width: '33%', pl: '1.25rem' }}>
+											{visitor.email ? visitor.email : 'N/A'}
+										</TableCell>
+										<TableCell sx={{ width: '23%', textAlign: 'center' }}>
+											{formatDateTime(visitor.visitedAt, { includeTime: true })}
+										</TableCell>
+										<TableCell sx={{ width: '17%', textAlign: 'center' }}>
+											{visitor.visitorMetaData ? visitor.visitorMetaData : 'N/A'}
+										</TableCell>
+									</TableRow>
+								))
+							)}
+						</TableBody>
+					</Table>
+				</TableContainer>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/src/hooks/documents/useFetchLinkVisitors.ts
+++ b/src/hooks/documents/useFetchLinkVisitors.ts
@@ -1,0 +1,25 @@
+import { LinkVisitor } from '@/shared/models';
+
+import { useQuery } from '@tanstack/react-query';
+import axios from 'axios';
+
+export default function useFetchLinkVisitors(
+	documentId: string,
+	linkId: string,
+	enabled?: boolean,
+) {
+	const fetchLinkVisitors = async (): Promise<LinkVisitor[]> => {
+		const response = await axios.get(`/api/documents/${documentId}/links/${linkId}/log`);
+		return response.data.data;
+	};
+
+	return useQuery({
+		queryKey: ['linkVisitors', documentId, linkId], // Unique cache per document link
+		queryFn: fetchLinkVisitors, // Function to fetch data
+		enabled, // Only run when modal is open
+		staleTime: 1000 * 30, // Data stays fresh for 30 seconds before being marked stale
+		refetchInterval: 1000 * 60, // Background refetch every 60 seconds
+		refetchOnWindowFocus: true, // Refetch when user focuses the window
+		refetchOnReconnect: true, // Refetch when the user reconnects to the internet
+	});
+}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,10 +1,13 @@
 export { default as useFetchContacts } from './contacts/useFetchContacts';
 
+export { default as useDocumentAccess } from './documentAccess/useDocumentAccess';
+export { default as useVisitorSubmission } from './documentAccess/useVisitorSubmission';
+
 export { default as useFetchDocuments } from './documents/useFetchDocuments';
 export { default as useUploadDocument } from './documents/useUploadDocument';
 export { default as useDeleteDocument } from './documents/useDeleteDocument';
-
 export { default as useCreateLink } from './documents/useCreateLink';
+export { default as useFetchLinkVisitors } from './documents/useFetchLinkVisitors';
 
 export { default as useDocumentAnalytics } from './useDocumentAnalytics';
 export { default as useDocumentData } from './useDocumentData';
@@ -14,5 +17,3 @@ export { useModal } from './useModal';
 export { useSort } from './useSort';
 export { useToast } from './useToast';
 export { useValidatedFormData } from './useValidatedFormData';
-export { default as useDocumentAccess } from './documentAccess/useDocumentAccess';
-export { default as useVisitorSubmission } from './documentAccess/useVisitorSubmission';

--- a/src/shared/models/index.ts
+++ b/src/shared/models/index.ts
@@ -13,3 +13,4 @@ export type { LinkDetail } from './linkModels';
 
 export type { User } from './userModels';
 export type { Contact } from './userModels';
+export type { LinkVisitor } from './userModels';

--- a/src/shared/models/linkModels.ts
+++ b/src/shared/models/linkModels.ts
@@ -70,9 +70,9 @@ export interface LinkData {
 // =========== LINK DETAIL ===========
 
 export interface LinkDetail {
-	documentLinkId: string; // unique string
+	linkId: string; // unique string
 	alias: string; // The links's friendly name
-	document_id: string; // The document_id from DB
+	documentId: string; // The document_id from DB
 	createdLink: string; // The linkUrl from DB
 	lastActivity: Date; // The link's updatedAt
 	linkViews: number; // If you track actual link views, you can use a real value

--- a/src/shared/models/userModels.ts
+++ b/src/shared/models/userModels.ts
@@ -1,3 +1,5 @@
+import { ReactNode } from 'react';
+
 // =========== USER TYPE ===========
 
 export interface User {
@@ -22,4 +24,15 @@ export interface Contact {
 	downloads: number;
 	duration: string;
 	completion: string;
+}
+
+// =========== LINK VISITOR DETAIL ===========
+
+export interface LinkVisitor {
+	id: number;
+	linkId: string;
+	name: string;
+	email: string;
+	visitedAt: string;
+	visitorMetaData: ReactNode;
 }


### PR DESCRIPTION

### This closes issue #273.

---

### ✅ Implemented

### Backend

• Created an API endpoint at  
  `/api/documents/[documentId]/links/[linkId]/log`  
  to retrieve visitors for a specific link within a document.

• Updated the visitor logging logic in  
  `/api/public_links/[linkId]/access`:  
  If the link is fully public (i.e., no password and no visitor fields), do not create a `DocumentLinkVisitor` record in the database.

• Updated the contact storage logic in  
  `/api/contacts`:  
  If both email and name are available for a link visitor, store the visitor's details in the `contacts` table (used in the UI).

### Frontend

• Created a new feature: `LinkVisitorModal.tsx`  
  This displays the visitor log for each specific link in the document details section.  
  Includes the following columns: **Name**, **Email**, **Visited At**, and **Metadata**, sorted by **Visited At DESC**.

• Added an icon button with a tooltip message to the link table in `InfoTable.tsx` to trigger the `LinkVisitorModal`.

• Enabled a scrollbar in the modal for overflow content.

• Created a `useFetchLinkVisitors` hook for handling API calls using React Query (TanStack Query).

• Integrated the query logic into the `LinkVisitorModal`.

• Added a `LinkVisitor` interface to `userModels.ts` for type safety.

### UI Changes

🎥 **LinkVisitor modal and visitor tracking enhancements:**
➡️ [Watch the video here](https://github.com/user-attachments/assets/437b8564-5b6f-4739-a506-492285aedac3)



